### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/kromskii2/test/security/code-scanning/1](https://github.com/kromskii2/test/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `build` job to explicitly limit the `GITHUB_TOKEN` permissions to the minimum required. Since the `build` job only runs tests and does not need write access, the `contents: read` permission is sufficient. This change ensures that the `build` job cannot inadvertently modify repository contents or perform other write actions.

The `permissions` block should be added directly under the `build` job definition, similar to how it is already defined for the `publish-gpr` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
